### PR TITLE
least privileges for `config-connector` sa

### DIFF
--- a/2-gcp/README.md
+++ b/2-gcp/README.md
@@ -52,10 +52,6 @@ gcloud container clusters get-credentials cymbal-shops --zone us-central1-c --pr
 ```
 gcloud iam service-accounts create config-connector
 
-gcloud projects add-iam-policy-binding ${PROJECT_ID} \
-    --member="serviceAccount:config-connector@${PROJECT_ID}.iam.gserviceaccount.com" \
-    --role="roles/owner"
-
 gcloud iam service-accounts add-iam-policy-binding \
 config-connector@${PROJECT_ID}.iam.gserviceaccount.com \
     --member="serviceAccount:${PROJECT_ID}.svc.id.goog[cnrm-system/cnrm-controller-manager]" \
@@ -95,7 +91,7 @@ pod/cnrm-webhook-manager-567789d76c-thcj5 condition met
 
 ### 6 - Set up Workload Identity for GKE. 
 
-GKE Workload Identity is a mapping from a GCP IAM service account to a Kubernetes Service Account. You then assign IAM roles to your GCP service account which then apply to a K8s service account, mounted into a pod. This allows your Kubernetes workloads to have specific GCP permissions. In our case, we'll configure the GCP service account [from within Config Connector](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#config-connector), then use that service account mapping to let the Cymbal Shops app (inside GKE) access Cloud Memorystore (in hosted GCP).
+GKE Workload Identity is a mapping from a GCP IAM service account to a Kubernetes Service Account. You then assign IAM roles to your GCP service account which then apply to a K8s service account, mounted into a pod. This allows your Kubernetes workloads to have specific GCP permissions. In our case, we'll configure the GCP service account [with Config Connector](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#config-connector).
 
 Create your Kubernetes service account:
 
@@ -157,12 +153,12 @@ kubectl annotate serviceaccount \
 
 ### 7 - Use Config Connector to create a Cloud Memorystore Instance.
 
-- Grant the `cymbal-gsa` Google service account `Cloud Memorystore` read-write permissions.
+- Grant the `config-connector` Google service account `Cloud Memorystore` read-write permissions.
 
 ```
 gcloud projects add-iam-policy-binding ${PROJECT_ID} \
-  --member "serviceAccount:cymbal-gsa@${PROJECT_ID}.iam.gserviceaccount.com" \
-  --role roles/redis.editor
+  --member "serviceAccount:config-connector@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role roles/redis.admin
 ```
 
 - Use Config Connector to spin up a new [Cloud Memorystore Redis](https://cloud.google.com/config-connector/docs/reference/resource-docs/redis/redisinstance#sample_yamls) instance in your project.

--- a/2-gcp/README.md
+++ b/2-gcp/README.md
@@ -100,7 +100,15 @@ kubectl create namespace cymbal-shops
 kubectl create serviceaccount --namespace cymbal-shops cymbal-ksa
 ```
 
-Create the GCP Service Account as YAML:
+Grant the `config-connector` Google service account `Cloud Memorystore` service account creator permissions.
+
+```
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+  --member "serviceAccount:config-connector@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role roles/iam.serviceAccountCreator
+```
+
+Use Config Connector to create `cymbal-gsa` [Cloud Service Account](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iamserviceaccount#sample_yamls) in your project:
 
 ```
 kubectl apply -f cymbal-gsa.yaml
@@ -153,7 +161,7 @@ kubectl annotate serviceaccount \
 
 ### 7 - Use Config Connector to create a Cloud Memorystore Instance.
 
-- Grant the `config-connector` Google service account `Cloud Memorystore` read-write permissions.
+- Grant the `config-connector` Google service account `Cloud Memorystore` instance creator permissions.
 
 ```
 gcloud projects add-iam-policy-binding ${PROJECT_ID} \


### PR DESCRIPTION
The `cymbal-gsa` doesn't need the `redis/editor` role in order to reach out the redis IP address.

Furthermore, granting the least privileges roles for the `config-connector` sa:
- `roles/iam.serviceAccountCreator` in order to create the `cymbal-gsa` gcp service account https://cloud.google.com/iam/docs/understanding-roles#service-accounts-roles
- `roles/redis.admin` in order to create the redis instance, ref: https://cloud.google.com/memorystore/docs/redis/access-control